### PR TITLE
[fixed] overzealous autocompletion

### DIFF
--- a/dist/amd/autocomplete.js
+++ b/dist/amd/autocomplete.js
@@ -263,7 +263,7 @@ define(
        * @method handleKeydown
        * @private
        */
-     
+
       handleKeydown: function(event) {
         var map = this.get('keydownMap');
         var method = map[event.keyCode];
@@ -318,7 +318,7 @@ define(
         if (input === '') {
           return;
         }
-        if (label.toLowerCase().indexOf(input.toLowerCase()) == -1) {
+        if (label.toLowerCase().indexOf(input.toLowerCase()) !== 0) {
           return
         }
         var fragment = label.substring(input.length);

--- a/dist/cjs/autocomplete.js
+++ b/dist/cjs/autocomplete.js
@@ -260,7 +260,7 @@ exports["default"] = Ember.Component.extend({
    * @method handleKeydown
    * @private
    */
- 
+
   handleKeydown: function(event) {
     var map = this.get('keydownMap');
     var method = map[event.keyCode];
@@ -315,7 +315,7 @@ exports["default"] = Ember.Component.extend({
     if (input === '') {
       return;
     }
-    if (label.toLowerCase().indexOf(input.toLowerCase()) == -1) {
+    if (label.toLowerCase().indexOf(input.toLowerCase()) !== 0) {
       return
     }
     var fragment = label.substring(input.length);

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -612,7 +612,7 @@ exports["default"] = Ember.Component.extend({
    * @method handleKeydown
    * @private
    */
- 
+
   handleKeydown: function(event) {
     var map = this.get('keydownMap');
     var method = map[event.keyCode];
@@ -667,7 +667,7 @@ exports["default"] = Ember.Component.extend({
     if (input === '') {
       return;
     }
-    if (label.toLowerCase().indexOf(input.toLowerCase()) == -1) {
+    if (label.toLowerCase().indexOf(input.toLowerCase()) !== 0) {
       return
     }
     var fragment = label.substring(input.length);

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -86,7 +86,8 @@ define("ic-autocomplete/autocomplete-input",
       }.on('focusIn')
 
     });
-  });define("ic-autocomplete/autocomplete-list",
+  });
+define("ic-autocomplete/autocomplete-list",
   ["ember","exports"],
   function(__dependency1__, __exports__) {
     "use strict";
@@ -134,7 +135,8 @@ define("ic-autocomplete/autocomplete-input",
       }.on('didInsertElement')
 
     });
-  });define("ic-autocomplete/autocomplete-option",
+  });
+define("ic-autocomplete/autocomplete-option",
   ["ember","exports"],
   function(__dependency1__, __exports__) {
     "use strict";
@@ -311,7 +313,8 @@ define("ic-autocomplete/autocomplete-input",
       }
 
     });
-  });define("ic-autocomplete/autocomplete-toggle",
+  });
+define("ic-autocomplete/autocomplete-toggle",
   ["ember","exports"],
   function(__dependency1__, __exports__) {
     "use strict";
@@ -357,7 +360,8 @@ define("ic-autocomplete/autocomplete-input",
       }.on('click')
 
     });
-  });define("ic-autocomplete/autocomplete",
+  });
+define("ic-autocomplete/autocomplete",
   ["ember","exports"],
   function(__dependency1__, __exports__) {
     "use strict";
@@ -622,7 +626,7 @@ define("ic-autocomplete/autocomplete-input",
        * @method handleKeydown
        * @private
        */
-     
+
       handleKeydown: function(event) {
         var map = this.get('keydownMap');
         var method = map[event.keyCode];
@@ -677,7 +681,7 @@ define("ic-autocomplete/autocomplete-input",
         if (input === '') {
           return;
         }
-        if (label.toLowerCase().indexOf(input.toLowerCase()) == -1) {
+        if (label.toLowerCase().indexOf(input.toLowerCase()) !== 0) {
           return
         }
         var fragment = label.substring(input.length);
@@ -939,7 +943,8 @@ define("ic-autocomplete/autocomplete-input",
       }.observes('value')
 
     });
-  });define("ic-autocomplete",
+  });
+define("ic-autocomplete",
   ["ember","./templates/autocomplete-css","./templates/autocomplete","./autocomplete","./autocomplete-option","./autocomplete-toggle","./autocomplete-input","./autocomplete-list","exports"],
   function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, __dependency5__, __dependency6__, __dependency7__, __dependency8__, __exports__) {
     "use strict";
@@ -972,7 +977,8 @@ define("ic-autocomplete/autocomplete-input",
     __exports__.AutocompleteToggleComponent = AutocompleteToggleComponent;
     __exports__.AutocompleteInputComponent = AutocompleteInputComponent;
     __exports__.AutocompleteListComponent = AutocompleteListComponent;
-  });define("ic-autocomplete/templates/autocomplete-css",
+  });
+define("ic-autocomplete/templates/autocomplete-css",
   ["ember","exports"],
   function(__dependency1__, __exports__) {
     "use strict";
@@ -986,7 +992,8 @@ define("ic-autocomplete/autocomplete-input",
       data.buffer.push("ic-autocomplete {\n  display: inline-block;\n  position: relative;\n}\n\nic-autocomplete-list {\n  display: none;\n  position: absolute;\n  z-index: 1;\n  border: 1px solid #aaa;\n  background: #fff;\n  top: 100%;\n  padding: 5px 0px;\n  max-height: 400px;\n  overflow: auto;\n  font-size: 12px;\n  width: 100%;\n  -moz-box-sizing: border-box;\n  -ms-box-sizing: border-box;\n  box-sizing: border-box;\n}\n\nic-autocomplete[is-open] ic-autocomplete-list {\n  display: block;\n}\n\nic-autocomplete-option {\n  display: block;\n  padding: 2px 16px;\n  cursor: default;\n}\n\nic-autocomplete-option:focus {\n  outline: 0;\n  color: white;\n  background: hsl(200, 50%, 50%);\n}\n\nic-autocomplete-option[selected]:before {\n  content: '✓';\n  position: absolute;\n  left: 4px;\n}\n\nic-autocomplete-toggle {\n  display: inline-block;\n  outline: none;\n  position: absolute;\n  top: 2px;\n  right: 6px;\n  font-size: 14px;\n  cursor: default;\n}\n\n.ic-autocomplete-input {\n  position: relative;\n  padding-right: 20px;\n  width: 100%;\n  -moz-box-sizing: border-box;\n  -ms-box-sizing: border-box;\n  box-sizing: border-box;\n}\n\n");
       
     });
-  });define("ic-autocomplete/templates/autocomplete",
+  });
+define("ic-autocomplete/templates/autocomplete",
   ["ember","exports"],
   function(__dependency1__, __exports__) {
     "use strict";

--- a/lib/autocomplete.js
+++ b/lib/autocomplete.js
@@ -259,7 +259,7 @@ export default Ember.Component.extend({
    * @method handleKeydown
    * @private
    */
- 
+
   handleKeydown: function(event) {
     var map = this.get('keydownMap');
     var method = map[event.keyCode];
@@ -314,7 +314,7 @@ export default Ember.Component.extend({
     if (input === '') {
       return;
     }
-    if (label.toLowerCase().indexOf(input.toLowerCase()) == -1) {
+    if (label.toLowerCase().indexOf(input.toLowerCase()) !== 0) {
       return
     }
     var fragment = label.substring(input.length);

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -123,6 +123,14 @@ test('autocompletes text', function() {
           assertSelection('tah', 'selects fragment');
 });
 
+test('does not autocomplete overzealously', function() {
+  setup(this);
+  input[0].value = 't';
+  input.simulate('keyup', {keyCode: 116});
+          equal(input[0].value, 't');
+          assertSelection('', 'selects fragment');
+});
+
 test('does not autocomplete on backspace', function() {
   setup(this);
   input[0].value = 'Uta';


### PR DESCRIPTION
This PR changes the component so that it only autocompletes if the matched option starts-with (instead of contains) the user input.

If I start with an empty textbox and type "t", the component autocompletes to "Utah" (the "ah" being highlighted/selected).

This is bad because if the first key press were a typo, a user expects to hit backspace one time and end up with an empty textbox.  Instead, the textbox still contains "U".
