### PR TITLE
fire on-select-not-in-list when option not in list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "ember-qunit": "0.1.3",
-    "jquery-simulate": "https://raw.github.com/jquery/jquery-simulate/master/jquery.simulate.js",
+    "jquery-simulate": "*",
     "ember-canary": "http://builds.emberjs.com/canary/ember.js"
   }
 }

--- a/dist/amd/autocomplete.js
+++ b/dist/amd/autocomplete.js
@@ -265,7 +265,7 @@ define(
        * @method handleKeydown
        * @private
        */
-     
+
       handleKeydown: function(event) {
         var map = this.get('keydownMap');
         var method = map[event.keyCode];
@@ -477,6 +477,8 @@ define(
           }
           this.selectOption(option, {focus: false, focusOption: false});
           this.set('autocompletedOption', null);
+        } else {
+          this.sendAction('on-select-not-in-list', option);
         }
       },
 

--- a/dist/cjs/autocomplete.js
+++ b/dist/cjs/autocomplete.js
@@ -262,7 +262,7 @@ exports["default"] = Ember.Component.extend({
    * @method handleKeydown
    * @private
    */
- 
+
   handleKeydown: function(event) {
     var map = this.get('keydownMap');
     var method = map[event.keyCode];
@@ -474,6 +474,8 @@ exports["default"] = Ember.Component.extend({
       }
       this.selectOption(option, {focus: false, focusOption: false});
       this.set('autocompletedOption', null);
+    } else {
+      this.sendAction('on-select-not-in-list', option);
     }
   },
 

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -614,7 +614,7 @@ exports["default"] = Ember.Component.extend({
    * @method handleKeydown
    * @private
    */
- 
+
   handleKeydown: function(event) {
     var map = this.get('keydownMap');
     var method = map[event.keyCode];
@@ -826,6 +826,8 @@ exports["default"] = Ember.Component.extend({
       }
       this.selectOption(option, {focus: false, focusOption: false});
       this.set('autocompletedOption', null);
+    } else {
+      this.sendAction('on-select-not-in-list', option);
     }
   },
 

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -628,7 +628,7 @@ define("ic-autocomplete/autocomplete",
        * @method handleKeydown
        * @private
        */
-     
+
       handleKeydown: function(event) {
         var map = this.get('keydownMap');
         var method = map[event.keyCode];
@@ -840,6 +840,8 @@ define("ic-autocomplete/autocomplete",
           }
           this.selectOption(option, {focus: false, focusOption: false});
           this.set('autocompletedOption', null);
+        } else {
+          this.sendAction('on-select-not-in-list', option);
         }
       },
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -26,6 +26,7 @@ ic-autocomplete-list {
     on-input="filterStates"
     on-select="resetStates"
     placeholder="Enter or pick a state"
+    on-select-not-in-list="notInList"
   }}
     {{#each filteredStates}}
       {{#ic-autocomplete-option value=id label=name}}{{name}}{{/ic-autocomplete-option}}
@@ -102,7 +103,11 @@ ic-autocomplete-list {
 
       setMovieSearch: throttle(function(autocomplete, term) {
         this.set('movieSearch', term);
-      }, 500)
+      }, 500),
+
+      notInList: function(text){
+        alert('You entered ' + text + ' but it is not in the list!');
+      },
     },
 
     filter: function(term) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,6 +8,7 @@ module.exports = function(config) {
       'bower_components/handlebars/handlebars.js',
       'bower_components/ember/ember.js',
       'bower_components/ember-qunit/dist/globals/main.js',
+      'bower_components/jquery-simulate/jquery.simulate.js',
       'dist/globals/main.js',
       // when running broccoli serve, we use this instead
       'http://localhost:4200/globals/main.js',

--- a/lib/autocomplete.js
+++ b/lib/autocomplete.js
@@ -261,7 +261,7 @@ export default Ember.Component.extend({
    * @method handleKeydown
    * @private
    */
- 
+
   handleKeydown: function(event) {
     var map = this.get('keydownMap');
     var method = map[event.keyCode];
@@ -473,6 +473,8 @@ export default Ember.Component.extend({
       }
       this.selectOption(option, {focus: false, focusOption: false});
       this.set('autocompletedOption', null);
+    } else {
+      this.sendAction('on-select-not-in-list', this.get('inputValue'));
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   "devDependencies": {
     "bower": "^1.3.3",
     "broccoli": "^0.12.3",
-    "qunitjs": "~1.12.0",
-    "broccoli-dist-es6-module": "^0.2.0",
     "broccoli-cli": "0.0.1",
+    "broccoli-dist-es6-module": "^0.2.0",
     "broccoli-template-compiler": "^1.4.1",
+    "karma": "^0.12.19",
+    "karma-qunit": "^0.1.3",
+    "qunitjs": "^1.14.0",
     "rf-release": "^0.1.2",
     "testem": "^0.6.15"
   },

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -73,6 +73,17 @@ test('enter selects focused option', function() {
           assertClosed();
 });
 
+test('enter without a matched option fires on-select-not-in-list', function(){
+  expect(2);
+  setup(this);
+  input.val('Literally not in the list').trigger('change');
+  component.sendAction = function(actionName, value){
+    equal(actionName, 'on-select-not-in-list');
+    equal(value, 'Literally not in the list');
+  };
+  input.simulate('keydown', {keyCode: 13});
+});
+
 test('spacebar selects focused option', function() {
   setup(this);
   openWithDownArrow();


### PR DESCRIPTION
supports the “find or create” use case.
