### PR TITLE
registerWithAutocomplete on didInsertElement

### DIFF
--- a/dist/amd/autocomplete-option.js
+++ b/dist/amd/autocomplete-option.js
@@ -77,7 +77,7 @@ define(
 
       registerWithAutocomplete: function() {
         this.get('autocomplete').registerOption(this);
-      }.on('willInsertElement'),
+      }.on('didInsertElement'),
 
       /**
        * Unregisters itself with the suggest component.

--- a/dist/amd/autocomplete.js
+++ b/dist/amd/autocomplete.js
@@ -15,6 +15,7 @@ define(
       inputValue: '',
 
       autocomplete: true,
+      replaceInput: true,
 
       /**
        * Two-way bound property representing the current value.
@@ -204,7 +205,7 @@ define(
             this.selectOption(option, {focus: false});
           }
         }
-        if (this.get('isOpen') && this.get('inputValue')) {
+        if (this.get('isOpen') && this.get('inputValue') && this.get('replaceInput')) {
           Ember.run.scheduleOnce('afterRender', this, 'autocompleteText');
         }
       },
@@ -364,7 +365,7 @@ define(
         }
         this.sendAction('on-input', this, this.get('inputValue'));
         // TODO: later because ???
-        if (this.get('autocomplete')) {
+        if (this.get('autocomplete') && this.get('replaceInput')) {
           Ember.run.scheduleOnce('afterRender', this, 'autocompleteText');
         }
       }.observes('inputValue'),

--- a/dist/cjs/autocomplete-option.js
+++ b/dist/cjs/autocomplete-option.js
@@ -74,7 +74,7 @@ exports["default"] = Ember.Component.extend({
 
   registerWithAutocomplete: function() {
     this.get('autocomplete').registerOption(this);
-  }.on('willInsertElement'),
+  }.on('didInsertElement'),
 
   /**
    * Unregisters itself with the suggest component.

--- a/dist/cjs/autocomplete.js
+++ b/dist/cjs/autocomplete.js
@@ -12,6 +12,7 @@ exports["default"] = Ember.Component.extend({
   inputValue: '',
 
   autocomplete: true,
+  replaceInput: true,
 
   /**
    * Two-way bound property representing the current value.
@@ -201,7 +202,7 @@ exports["default"] = Ember.Component.extend({
         this.selectOption(option, {focus: false});
       }
     }
-    if (this.get('isOpen') && this.get('inputValue')) {
+    if (this.get('isOpen') && this.get('inputValue') && this.get('replaceInput')) {
       Ember.run.scheduleOnce('afterRender', this, 'autocompleteText');
     }
   },
@@ -361,7 +362,7 @@ exports["default"] = Ember.Component.extend({
     }
     this.sendAction('on-input', this, this.get('inputValue'));
     // TODO: later because ???
-    if (this.get('autocomplete')) {
+    if (this.get('autocomplete') && this.get('replaceInput')) {
       Ember.run.scheduleOnce('afterRender', this, 'autocompleteText');
     }
   }.observes('inputValue'),

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -207,7 +207,7 @@ exports["default"] = Ember.Component.extend({
 
   registerWithAutocomplete: function() {
     this.get('autocomplete').registerOption(this);
-  }.on('willInsertElement'),
+  }.on('didInsertElement'),
 
   /**
    * Unregisters itself with the suggest component.

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -364,6 +364,7 @@ exports["default"] = Ember.Component.extend({
   inputValue: '',
 
   autocomplete: true,
+  replaceInput: true,
 
   /**
    * Two-way bound property representing the current value.
@@ -553,7 +554,7 @@ exports["default"] = Ember.Component.extend({
         this.selectOption(option, {focus: false});
       }
     }
-    if (this.get('isOpen') && this.get('inputValue')) {
+    if (this.get('isOpen') && this.get('inputValue') && this.get('replaceInput')) {
       Ember.run.scheduleOnce('afterRender', this, 'autocompleteText');
     }
   },
@@ -713,7 +714,7 @@ exports["default"] = Ember.Component.extend({
     }
     this.sendAction('on-input', this, this.get('inputValue'));
     // TODO: later because ???
-    if (this.get('autocomplete')) {
+    if (this.get('autocomplete') && this.get('replaceInput')) {
       Ember.run.scheduleOnce('afterRender', this, 'autocompleteText');
     }
   }.observes('inputValue'),

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -215,7 +215,7 @@ define("ic-autocomplete/autocomplete-option",
 
       registerWithAutocomplete: function() {
         this.get('autocomplete').registerOption(this);
-      }.on('willInsertElement'),
+      }.on('didInsertElement'),
 
       /**
        * Unregisters itself with the suggest component.

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -378,6 +378,7 @@ define("ic-autocomplete/autocomplete",
       inputValue: '',
 
       autocomplete: true,
+      replaceInput: true,
 
       /**
        * Two-way bound property representing the current value.
@@ -567,7 +568,7 @@ define("ic-autocomplete/autocomplete",
             this.selectOption(option, {focus: false});
           }
         }
-        if (this.get('isOpen') && this.get('inputValue')) {
+        if (this.get('isOpen') && this.get('inputValue') && this.get('replaceInput')) {
           Ember.run.scheduleOnce('afterRender', this, 'autocompleteText');
         }
       },
@@ -727,7 +728,7 @@ define("ic-autocomplete/autocomplete",
         }
         this.sendAction('on-input', this, this.get('inputValue'));
         // TODO: later because ???
-        if (this.get('autocomplete')) {
+        if (this.get('autocomplete') && this.get('replaceInput')) {
           Ember.run.scheduleOnce('afterRender', this, 'autocompleteText');
         }
       }.observes('inputValue'),

--- a/lib/autocomplete-option.js
+++ b/lib/autocomplete-option.js
@@ -73,7 +73,7 @@ export default Ember.Component.extend({
 
   registerWithAutocomplete: function() {
     this.get('autocomplete').registerOption(this);
-  }.on('willInsertElement'),
+  }.on('didInsertElement'),
 
   /**
    * Unregisters itself with the suggest component.

--- a/lib/autocomplete.js
+++ b/lib/autocomplete.js
@@ -11,6 +11,7 @@ export default Ember.Component.extend({
   inputValue: '',
 
   autocomplete: true,
+  replaceInput: true,
 
   /**
    * Two-way bound property representing the current value.
@@ -200,7 +201,7 @@ export default Ember.Component.extend({
         this.selectOption(option, {focus: false});
       }
     }
-    if (this.get('isOpen') && this.get('inputValue')) {
+    if (this.get('isOpen') && this.get('inputValue') && this.get('replaceInput')) {
       Ember.run.scheduleOnce('afterRender', this, 'autocompleteText');
     }
   },
@@ -360,7 +361,7 @@ export default Ember.Component.extend({
     }
     this.sendAction('on-input', this, this.get('inputValue'));
     // TODO: later because ???
-    if (this.get('autocomplete')) {
+    if (this.get('autocomplete') && this.get('replaceInput')) {
       Ember.run.scheduleOnce('afterRender', this, 'autocompleteText');
     }
   }.observes('inputValue'),


### PR DESCRIPTION
In some cases, when transitioning to a view that uses ic-autocomplete, I was getting the error `Cannot read property 'focus' of null`, which refers to this line:
https://github.com/instructure/ic-autocomplete/blob/c14fac737a21072352f7d8d0ebd59af1df6c38fa/lib/autocomplete-option.js#L124

It seems like the component is trying to access its element before the element exists. Changing `willInsertElement` to `didInsertElement` fixes the bugs for me.
